### PR TITLE
Bug Fix

### DIFF
--- a/macros/nozzle_clean.cfg
+++ b/macros/nozzle_clean.cfg
@@ -8,7 +8,7 @@ gcode:
         {% set tools = printer.toolchanger.tool_numbers %}
         {% set clean_temp = printer['gcode_macro _static_variable'].clean_temp %}
         G90
-        G1 F30000
+        # G1 F30000 - To be reomoved
         ## Get to toolchange height ---------------------------------
         {% if printer.toolhead.position[2] < printer['toolchanger'].params_min_z %}
             G0 Z{printer['toolchanger'].params_min_z|float} F9000

--- a/macros/offsets_adjust_record.cfg
+++ b/macros/offsets_adjust_record.cfg
@@ -35,7 +35,7 @@ gcode:
     {% if zr != 0.0 %}
         SET_GCODE_VARIABLE MACRO=_CURRENT_OFFSET  VARIABLE=zg  VALUE={ zr + printer["gcode_macro _CURRENT_OFFSET"].zg|float }
     {% endif %}
-    M400
+    # M400
 
     ## Overwrite the current offset with absolute offset, only if it is to reset the offset.
     {% if xa == 0.0 %}
@@ -47,7 +47,7 @@ gcode:
     {% if za == 0.0 %}
         SET_GCODE_VARIABLE MACRO=_CURRENT_OFFSET  VARIABLE=zg  VALUE={ za|float }
     {% endif %}
-    M400
+    # M400
 
 #####################################################################
 #                        Working

--- a/macros/offsets_adjust_record.cfg
+++ b/macros/offsets_adjust_record.cfg
@@ -55,16 +55,19 @@ gcode:
 #--------------------------------------------------------------------
 [gcode_macro Z_OFFSET_APPLY_PROBE]
 rename_existing: _Z_OFFSET_APPLY_PROBE
+description: DISABLED. This is not needed for MissChanger
+gcode:
+    # _Z_OFFSET_APPLY_PROBE    # Disable this command. Because the object [tool_probe_endstop] is not needed for MissChanger
+    
+#--------------------------------------------------------------------
+[gcode_macro SAVE_CONFIG]
+rename_existing: _SAVE_CONFIG
 gcode:
     {% set zg = printer["gcode_macro _CURRENT_OFFSET"].zg|float %}
-    SAVE_BABYSTEPS OFFSET={zg}
-    _Z_OFFSET_APPLY_PROBE
-    
-# #--------------------------------------------------------------------
-# [gcode_macro SAVE_CONFIG]
-# rename_existing: _SAVE_CONFIG
-# gcode:
-#     _SAVE_CONFIG
+    {% if zg != 0.0 %}
+        SAVE_BABYSTEPS OFFSET={zg}
+    {% endif %}
+    _SAVE_CONFIG
 
 #--------------------------------------------------------------------
 [gcode_macro SET_GCODE_OFFSET]

--- a/macros/print_time_default.cfg
+++ b/macros/print_time_default.cfg
@@ -21,15 +21,18 @@ gcode:
     SET_HEATER_TEMPERATURE HEATER=heater_bed TARGET={params.BED_TEMP}
     RESPOND TYPE=echo MSG='{"Fan on..."}'
     {% if 'fan_generic fan_nevermore_stealthmax' in printer.configfile.config %}
+        {% set nmcs = printer['gcode_macro _static_variable'].nm_ciculation_speed|default(0.0)|float %}
+        {% set nmes = printer['gcode_macro _static_variable'].nm_exhaust_speed|default(0.0)|float %}
         {% if params.BED_TEMP|int > 80 %}
-            SET_FAN_SPEED FAN=fan_nevermore_stealthmax SPEED=0.75
+            SET_FAN_SPEED FAN=fan_nevermore_stealthmax SPEED={nmcs}
         {% else %}
-            SET_FAN_SPEED FAN=fan_nevermore_stealthmax SPEED=1.00
+            SET_FAN_SPEED FAN=fan_nevermore_stealthmax SPEED={nmes}
         {% endif %}
     {% endif %}
     {% if 'fan_generic fan_chamber_heater' in printer.configfile.config %}
+        {% set chanberfs = printer['gcode_macro _static_variable'].chamber_ciculation_speed|default(0.0)|float %}
         {% if params.BED_TEMP|int > 80 %}
-            SET_FAN_SPEED FAN=fan_chamber_heater SPEED=1.00
+            SET_FAN_SPEED FAN=fan_chamber_heater SPEED={chanberfs}
         {% endif %}
     {% endif %}
     M190 S{params.BED_TEMP}

--- a/macros/print_time_default.cfg
+++ b/macros/print_time_default.cfg
@@ -152,16 +152,15 @@ gcode:
 [gcode_macro PRINT_END]                                     # Set PRINT_END as the end-of-print macro to customise the after-print action.
 gcode:
     ## Clear cache --------------------------------------------------
-    # M400                                                    # finish off and clear buffer
     RESPOND TYPE=echo MSG='PRINT_END...'
     ## --------------------------------------------------------------
     G91                                                     # relative position
     G0 Z1.00 F9000                                          # Remove nozzle
     G90
     SET_VELOCITY_LIMIT ACCEL=10000
-    _CLEAN_MID_PRINT
+    # _CLEAN_MID_PRINT
+    CLEAN_NOZZLE
     ## Clear print variables 2 --------------------------------------
-    # T0
     SET_GCODE_OFFSET Z_ADJUST={-1 * printer['gcode_macro _print_time'].thermo_z_offset} MOVE=1
     TURN_OFF_HEATERS                                        # Close the hot end
     _TOOLCHANGER_DISABLE_EXTRUDER_STEPPERS                  # Disable all extruders


### PR DESCRIPTION
Bug fixes:
1. Fix the bug where the tool-head would pause on baby-step.
2. Fix the bug where baby step cannot be save from Klipper Screen.

New feature:
1. Make fan speed controllable on the user side, using variables under `_static_variable`.

```
[gcode_macro _static_variable]
description: Global static variables that is used through out the configs
...
## Fan control
variable_nm_ciculation_speed: 0.75           # Nevermore Stealth Max fan speed in circulation mode
variable_nm_exhaust_speed: 1.00              # Nevermore Stealth Max fan speed in exhaust mode
variable_chamber_ciculation_speed: 0.55      # Chamber fan speed in chamber-heating mode
...
gcode:
```