### PR TITLE
Calibration routine optimisation

### DIFF
--- a/macros/print_time_default.cfg
+++ b/macros/print_time_default.cfg
@@ -55,10 +55,8 @@ gcode:
     G28                                                     # Homing
     ## Bed Mesh -----------------------------------------------------
     BED_MESH_CLEAR                                          # Unloading net beds
-    {% if 'exclude_object' in printer.configfile.config %}
-        {% if printer['exclude_object'].objects == null %}
-            BED_MESH_PROFILE LOAD=default                   # Loading the net bed
-        {% endif %}
+    {% if 'exclude_object' in printer.configfile.config and printer['exclude_object'].objects == null %}
+        BED_MESH_PROFILE LOAD=default                       # Loading the net bed
     {% else %}
         BED_MESH_CALIBRATE                                  # BED_MESH_CALIBRATE
     {% endif %}

--- a/macros/print_time_default.cfg
+++ b/macros/print_time_default.cfg
@@ -216,7 +216,7 @@ gcode:
                 SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE=0
             {% endif %}
             G90                                                                                                ; absolute positioning
-            G1 X{printer.toolhead.axis_maximum.x-20} Y{printer.toolhead.axis_maximum.y-20} F10000
+            G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-20} F10000
         {% else %}
             RESPOND TYPE=error MSG='CRASH PAUSE'
         {% endif %}

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -61,8 +61,8 @@ gcode:
     _CALIBRATE_MOVE_OVER_PROBE
     M400
     RESPOND TYPE=echo MSG='Check for Nudge...'
-    PROBE    # Probe to see if the Nudge is in place
-    M400     # Clear cache
+    PROBE                           # Probe to see if the Nudge is in place
+    M400                            # Clear cache
 #--------------------------------------------------------------------
 [gcode_macro _CALIBRATE_MOVE_OVER_PROBE]
 gcode:
@@ -183,7 +183,7 @@ gcode:
 #--------------------------------------------------------------------
 [gcode_macro _CTB_RECORD_SENSOR_Z]
 gcode:
-    {% set final_lift_z = printer['tools_calibrate'].final_lift_z|float %}
+    {% set final_lift_z = printer['gcode_macro _static_variable'].final_lift_z|float %}
     {% set cur_z = printer.toolhead.position[2]|float %}
     {% set sensor_z = cur_z - final_lift_z %}
     M400

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -62,8 +62,8 @@ gcode:
         _CALIBRATE_MOVE_OVER_PROBE
         M400
         RESPOND TYPE=echo MSG='Check for calibration probe...'
-        PROBE                           # Probe to see if the Nudge is in place
-        M400                            # Clear cache
+        PROBE    # Probe to see if the Nudge is in place
+        M400     # Clear cache
     {% endif %}
 #--------------------------------------------------------------------
 [gcode_macro _CALIBRATE_MOVE_OVER_PROBE]
@@ -93,7 +93,7 @@ gcode:
     {% set names  = printer.toolchanger.tool_names %}
     {% set safe_z = printer['gcode_macro _static_variable'].calibration_safe_z|float %}
     {% set abs_z  = printer['gcode_macro _static_variable'].calibration_abs_z_seperately|int %}
-    {% set pause  = printer['gcode_macro _static_variable'].calibration_stable_time|default(1000)|int %}
+    {% set pause  = printer['gcode_macro _static_variable'].probe_stable_time|default(1000)|int %}
     ## Messages
     {% if params.TOOL != null %}
         {% if params.TOOL != 0 %}
@@ -173,7 +173,7 @@ gcode:
     {% set safe_z  = printer['gcode_macro _static_variable'].calibration_safe_z|float %}
     {% set pin_z  = printer['gcode_macro _static_variable'].calibration_min_z|float %}
     {% set cur_z  = printer.toolhead.position[2]|float %}
-    {% set pause  = printer['gcode_macro _static_variable'].calibration_stable_time|default(0)|int %}
+    {% set pause  = printer['gcode_macro _static_variable'].probe_stable_time|default(1000)|int %}
     M400
     G4 P{pause}   # Pause and wait for physical stability
     M400

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -60,7 +60,7 @@ gcode:
     G28
     _CALIBRATE_MOVE_OVER_PROBE
     M400
-    RESPOND TYPE=echo MSG='Check for Nudge...'
+    RESPOND TYPE=echo MSG='Check for calibration probe...'
     PROBE                           # Probe to see if the Nudge is in place
     M400                            # Clear cache
 #--------------------------------------------------------------------
@@ -91,6 +91,7 @@ gcode:
     {% set names  = printer.toolchanger.tool_names %}
     {% set safe_z = printer['gcode_macro _static_variable'].calibration_safe_z|float %}
     {% set abs_z  = printer['gcode_macro _static_variable'].calibration_abs_z_seperately|int %}
+    {% set pause  = printer['gcode_macro _static_variable'].calibration_stable_time|default(1000)|int %}
     ## Messages
     {% if params.TOOL != null %}
         {% if params.TOOL != 0 %}
@@ -101,6 +102,9 @@ gcode:
     {% else %}
         RESPOND TYPE=echo MSG='Calibrate all tools...'
     {% endif %}
+    M400
+    G4 P{pause}   # Pause and wait for physical stability
+    M400
     ## Working routine
     {% if printer['quad_gantry_level'].applied == True and "xyz" in printer.toolhead.homed_axes and printer.tools_calibrate.calibration_probe_inactive == False %}
         {% if printer.toolhead.position[2]|float > printer['gcode_macro _static_variable'].calibration_min_z|float %}

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -9,7 +9,7 @@
 gcode:
     {% set safe_z  = printer['gcode_macro _static_variable'].calibration_safe_z|float %}
     _CPI_CHECK
-    {% if printer['quad_gantry_level'].applied == True and "xyz" in printer.toolhead.homed_axes %}
+    {% if printer['quad_gantry_level'].applied == True and "xyz" in printer.toolhead.homed_axes and printer.tools_calibrate.calibration_probe_inactive == False %}
         _CHECK_PROBE
         _CALIBRATE_TRIGGER_BOTTOM
         G1 Z{safe_z} F9000
@@ -19,6 +19,9 @@ gcode:
         {% endif %}
         {% if "xyz" not in printer.toolhead.homed_axes %}
             RESPOND TYPE=error MSG='Printer is not HOMED...'
+        {% endif %}
+        {% if printer.tools_calibrate.calibration_probe_inactive == True %}
+            RESPOND TYPE=error MSG='Calibration Probe is not in place...'
         {% endif %}
     {% endif %}
 #--------------------------------------------------------------------

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -121,6 +121,9 @@ gcode:
                 {% if params.TOOL != null %}
                     SELECT_TOOL T={params.TOOL}  RESTORE_AXIS=XYZ
                     _AFTER_SELECT_TOOL TOOL={params.TOOL}
+                    M400
+                    G4 P{pause}   # Pause and wait for physical stability
+                    M400
                     SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0 MOVE=1
                     STOP_TOOL_PROBE_CRASH_DETECTION
                     TOOL_CALIBRATE_TOOL_OFFSET
@@ -133,10 +136,10 @@ gcode:
                 {% else %}
                     {% for tool in tools[1:] %}
                         SELECT_TOOL T={tool}  RESTORE_AXIS=XYZ
+                        _AFTER_SELECT_TOOL TOOL={tool}
                         M400
                         G4 P{pause}   # Pause and wait for physical stability
                         M400
-                        _AFTER_SELECT_TOOL TOOL={tool}
                         SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0 MOVE=1
                         STOP_TOOL_PROBE_CRASH_DETECTION
                         TOOL_CALIBRATE_TOOL_OFFSET

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -133,6 +133,9 @@ gcode:
                 {% else %}
                     {% for tool in tools[1:] %}
                         SELECT_TOOL T={tool}  RESTORE_AXIS=XYZ
+                        M400
+                        G4 P{pause}   # Pause and wait for physical stability
+                        M400
                         _AFTER_SELECT_TOOL TOOL={tool}
                         SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0 MOVE=1
                         STOP_TOOL_PROBE_CRASH_DETECTION

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -9,7 +9,7 @@
 gcode:
     {% set safe_z  = printer['gcode_macro _static_variable'].calibration_safe_z|float %}
     _CPI_CHECK
-    {% if printer['quad_gantry_level'].applied == True and "xyz" in printer.toolhead.homed_axes and printer.tools_calibrate.calibration_probe_inactive == False %}
+    {% if printer['quad_gantry_level'].applied == True and "xyz" in printer.toolhead.homed_axes %}
         _CHECK_PROBE
         _CALIBRATE_TRIGGER_BOTTOM
         G1 Z{safe_z} F9000
@@ -56,13 +56,15 @@ gcode:
 #--------------------------------------------------------------------
 [gcode_macro _CHECK_PROBE]
 gcode:
-    T0
-    G28
-    _CALIBRATE_MOVE_OVER_PROBE
-    M400
-    RESPOND TYPE=echo MSG='Check for calibration probe...'
-    PROBE                           # Probe to see if the Nudge is in place
-    M400                            # Clear cache
+    {% if printer.tools_calibrate.calibration_probe_inactive == False %}
+        T0
+        G28
+        _CALIBRATE_MOVE_OVER_PROBE
+        M400
+        RESPOND TYPE=echo MSG='Check for calibration probe...'
+        PROBE                           # Probe to see if the Nudge is in place
+        M400                            # Clear cache
+    {% endif %}
 #--------------------------------------------------------------------
 [gcode_macro _CALIBRATE_MOVE_OVER_PROBE]
 gcode:

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -92,6 +92,8 @@ gcode:
     {% set tools  = printer.toolchanger.tool_numbers %}
     {% set names  = printer.toolchanger.tool_names %}
     {% set safe_z = printer['gcode_macro _static_variable'].calibration_safe_z|float %}
+    {% set pin_z  = printer['gcode_macro _static_variable'].calibration_min_z|float %}
+    {% set cur_z  = printer.toolhead.position[2]|float %}
     {% set abs_z  = printer['gcode_macro _static_variable'].calibration_abs_z_seperately|int %}
     {% set pause  = printer['gcode_macro _static_variable'].probe_stable_time|default(1000)|int %}
     ## Messages
@@ -104,71 +106,64 @@ gcode:
     {% else %}
         RESPOND TYPE=echo MSG='Calibrate all tools...'
     {% endif %}
-    M400
-    G4 P{pause}   # Pause and wait for physical stability
-    M400
     ## Working routine
-    {% if printer['quad_gantry_level'].applied == True and "xyz" in printer.toolhead.homed_axes and printer.tools_calibrate.calibration_probe_inactive == False %}
-        {% if printer.toolhead.position[2]|float > printer['gcode_macro _static_variable'].calibration_min_z|float %}
-            ## Start Probe Section
-            G28
-            _CALIBRATE_MOVE_OVER_PROBE
-            TOOL_LOCATE_SENSOR
-            {% if abs_z == 0 %}
-                TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
-            {% endif %}
-            {% if params.TOOL != "0" %}
-                {% if params.TOOL != null %}
-                    SELECT_TOOL T={params.TOOL}  RESTORE_AXIS=XYZ
-                    _AFTER_SELECT_TOOL TOOL={params.TOOL}
+    {% if printer.tools_calibrate.calibration_probe_inactive == False and cur_z > pin_z %}
+        ## Move away from the calibration probe, and wait for physical stability
+        M400
+        G0 Z{safe_z} F9000
+        G4 P{pause}
+        M400
+        ## Start Probe Section
+        G28
+        _CALIBRATE_MOVE_OVER_PROBE
+        TOOL_LOCATE_SENSOR
+        ## T0 z-offset
+        {% if abs_z == 0 %}
+            TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
+        {% endif %}
+        {% if params.TOOL != "0" %}
+            ## Single tool
+            {% if params.TOOL != null %}
+                SELECT_TOOL T={params.TOOL}  RESTORE_AXIS=XYZ
+                _AFTER_SELECT_TOOL TOOL={params.TOOL}
+                M400
+                G4 P{pause}   # Pause and wait for physical stability
+                M400
+                SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0 MOVE=1
+                STOP_TOOL_PROBE_CRASH_DETECTION
+                TOOL_CALIBRATE_TOOL_OFFSET
+                TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_x_offset VALUE="{% raw %}{x:0.6f}{% endraw %}"
+                TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_y_offset VALUE="{% raw %}{y:0.6f}{% endraw %}"
+                TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_z_offset VALUE="{% raw %}{z:0.6f}{% endraw %}"
+                {% if abs_z == 0 %}
+                    TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{params.TOOL}"
+                {% endif %}
+            ## All tools
+            {% else %}
+                {% for tool in tools[1:] %}
+                    SELECT_TOOL T={tool}  RESTORE_AXIS=XYZ
+                    _AFTER_SELECT_TOOL TOOL={tool}
                     M400
                     G4 P{pause}   # Pause and wait for physical stability
                     M400
                     SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0 MOVE=1
                     STOP_TOOL_PROBE_CRASH_DETECTION
                     TOOL_CALIBRATE_TOOL_OFFSET
-                    TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_x_offset VALUE="{% raw %}{x:0.6f}{% endraw %}"
-                    TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_y_offset VALUE="{% raw %}{y:0.6f}{% endraw %}"
-                    TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_z_offset VALUE="{% raw %}{z:0.6f}{% endraw %}"
+                    TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_x_offset VALUE="{% raw %}{x:0.6f}{% endraw %}"
+                    TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_y_offset VALUE="{% raw %}{y:0.6f}{% endraw %}"
+                    TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_z_offset VALUE="{% raw %}{z:0.6f}{% endraw %}"
                     {% if abs_z == 0 %}
-                        TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{params.TOOL}"
+                        TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{tool}"
                     {% endif %}
-                {% else %}
-                    {% for tool in tools[1:] %}
-                        SELECT_TOOL T={tool}  RESTORE_AXIS=XYZ
-                        _AFTER_SELECT_TOOL TOOL={tool}
-                        M400
-                        G4 P{pause}   # Pause and wait for physical stability
-                        M400
-                        SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0 MOVE=1
-                        STOP_TOOL_PROBE_CRASH_DETECTION
-                        TOOL_CALIBRATE_TOOL_OFFSET
-                        TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_x_offset VALUE="{% raw %}{x:0.6f}{% endraw %}"
-                        TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_y_offset VALUE="{% raw %}{y:0.6f}{% endraw %}"
-                        TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_z_offset VALUE="{% raw %}{z:0.6f}{% endraw %}"
-                        {% if abs_z == 0 %}
-                            TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{tool}"
-                        {% endif %}
-                    {% endfor %}
-                {% endif %}
+                {% endfor %}
             {% endif %}
-            T0
-            G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y - 30} Z{safe_z} F9000
-            ## End Probe Section
-        {% else %}
-            G1 Z{safe_z} F9000
-            RESPOND TYPE=error MSG='Calibration Probe is not in place...'
         {% endif %}
+        T0
+        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y - 30} Z{safe_z} F9000
+        ## End Probe Section
     {% else %}
-        {% if printer['quad_gantry_level'].applied == False %}
-            RESPOND TYPE=error MSG='Gantry is not LEVELED...'
-        {% endif %}
-        {% if "xyz" not in printer.toolhead.homed_axes %}
-            RESPOND TYPE=error MSG='Printer is not HOMED...'
-        {% endif %}
-        {% if printer.tools_calibrate.calibration_probe_inactive == True %}
-            RESPOND TYPE=error MSG='Calibration Probe is not in place...'
-        {% endif %}
+        G1 Z{safe_z} F9000
+        RESPOND TYPE=error MSG='Calibration Probe is not in place...'
     {% endif %}
 
 #--------------------------------------------------------------------

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -58,8 +58,8 @@ gcode:
     _CALIBRATE_MOVE_OVER_PROBE
     M400
     RESPOND TYPE=echo MSG='Check for Nudge...'
-    PROBE                           # Probe to see if the Nudge is in place
-    M400                            # Clear cache
+    PROBE    # Probe to see if the Nudge is in place
+    M400     # Clear cache
 #--------------------------------------------------------------------
 [gcode_macro _CALIBRATE_MOVE_OVER_PROBE]
 gcode:
@@ -180,7 +180,7 @@ gcode:
 #--------------------------------------------------------------------
 [gcode_macro _CTB_RECORD_SENSOR_Z]
 gcode:
-    {% set final_lift_z = printer['gcode_macro _static_variable'].final_lift_z|float %}
+    {% set final_lift_z = printer['tools_calibrate'].final_lift_z|float %}
     {% set cur_z = printer.toolhead.position[2]|float %}
     {% set sensor_z = cur_z - final_lift_z %}
     M400

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -173,6 +173,10 @@ gcode:
     {% set safe_z  = printer['gcode_macro _static_variable'].calibration_safe_z|float %}
     {% set pin_z  = printer['gcode_macro _static_variable'].calibration_min_z|float %}
     {% set cur_z  = printer.toolhead.position[2]|float %}
+    {% set pause  = printer['gcode_macro _static_variable'].calibration_stable_time|default(0)|int %}
+    M400
+    G4 P{pause}   # Pause and wait for physical stability
+    M400
     {% if printer.tools_calibrate.calibration_probe_inactive == False and cur_z > pin_z %}
         G28
         _CALIBRATE_MOVE_OVER_PROBE

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 ## Global variables ------------------------------------------
 REPO="VIN-y/klipper-toolchanger.git"
-BRANCH="alpha"
+BRANCH="test-machine"
 MACRODIR="misschanger_macros"
 SERVICE="/etc/systemd/system/ToolChanger.service"
 KLIPPER_PATH="${HOME}/klipper"

--- a/scripts/moonraker_update.txt
+++ b/scripts/moonraker_update.txt
@@ -2,6 +2,6 @@
 type: git_repo
 path: ~/klipper-toolchanger
 origin: https://github.com/VIN-y/klipper-toolchanger.git
-primary_branch: alpha
+primary_branch: test-machine
 is_system_service: True
 managed_services: ToolChanger


### PR DESCRIPTION
New step: rise and wait 1000ms after z-offset probing, for probe stabilisation. This can be changed via the variable:
```
[gcode_macro _static_variable]
description: Global static variables that is used through out the configs
## Tool-head calibration
variable_probe_stable_time: 1000             # Time (in ms) to wait for calibration probe to reset. Default: 1000

```