### PR TITLE
Test machine

### DIFF
--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -351,7 +351,6 @@ class Toolchanger:
                 self.run_gcode('after_change_gcode', after_change_gcode, extra_context)
 
             self._restore_axis(gcode_position, restore_axis, tool)
-
             self.gcode.run_script_from_command("RESTORE_GCODE_STATE NAME=_toolchange_state MOVE=0")
             
             if tool is not None:
@@ -439,12 +438,15 @@ class Toolchanger:
         }
         
         self.gcode.run_script_from_command("SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0")
+        self.gcode.run_script_from_command("SAVE_GCODE_STATE NAME=_toolchange_state")
         self.run_gcode('tool.dropoff_gcode', self.active_tool.dropoff_gcode, extra_context)
         self.gcode.run_script_from_command("DETECT_ACTIVE_TOOL_PROBE")
         self.run_gcode('tool.pickup_gcode', tool.pickup_gcode, extra_context)
         self.gcode.run_script_from_command("DETECT_ACTIVE_TOOL_PROBE")
 
-        self._restore_axis(gcode_position, restore_axis, None)
+        # self._restore_axis(gcode_position, restore_axis, None)
+        self._restore_axis(gcode_position, restore_axis, tool)
+        self.gcode.run_script_from_command("RESTORE_GCODE_STATE NAME=_toolchange_state MOVE=0")
         
         self.status = STATUS_READY
         gcmd.respond_info('Tool testing done')

--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -444,9 +444,7 @@ class Toolchanger:
         self.run_gcode('tool.pickup_gcode', tool.pickup_gcode, extra_context)
         self.gcode.run_script_from_command("DETECT_ACTIVE_TOOL_PROBE")
 
-        # self._restore_axis(gcode_position, restore_axis, None)
-        self._restore_axis(gcode_position, restore_axis, tool)
-
+        self._restore_axis(gcode_position, restore_axis, None)
         self.status = STATUS_READY
         gcmd.respond_info('Tool testing done')
 

--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -444,7 +444,9 @@ class Toolchanger:
         self.run_gcode('tool.pickup_gcode', tool.pickup_gcode, extra_context)
         self.gcode.run_script_from_command("DETECT_ACTIVE_TOOL_PROBE")
 
-        self._restore_axis(gcode_position, restore_axis, None)
+        # self._restore_axis(gcode_position, restore_axis, None)
+        self._restore_axis(gcode_position, restore_axis, tool)
+
         self.status = STATUS_READY
         gcmd.respond_info('Tool testing done')
 

--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -443,8 +443,6 @@ class Toolchanger:
         self.gcode.run_script_from_command("DETECT_ACTIVE_TOOL_PROBE")
         self.run_gcode('tool.pickup_gcode', tool.pickup_gcode, extra_context)
         self.gcode.run_script_from_command("DETECT_ACTIVE_TOOL_PROBE")
-
-        # self._restore_axis(gcode_position, restore_axis, None)
         self._restore_axis(gcode_position, restore_axis, tool)
         self.gcode.run_script_from_command("RESTORE_GCODE_STATE NAME=_toolchange_state MOVE=0")
         

--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -445,6 +445,7 @@ class Toolchanger:
         self.gcode.run_script_from_command("DETECT_ACTIVE_TOOL_PROBE")
 
         self._restore_axis(gcode_position, restore_axis, None)
+        
         self.status = STATUS_READY
         gcmd.respond_info('Tool testing done')
 

--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -437,9 +437,7 @@ class Toolchanger:
             'start_position': self._position_with_tool_offset(
                 gcode_position, 'xyz', tool)
         }
-
-        self.gcode.run_script_from_command("SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0")
-
+        
         self.gcode.run_script_from_command("SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0")
         self.run_gcode('tool.dropoff_gcode', self.active_tool.dropoff_gcode, extra_context)
         self.gcode.run_script_from_command("DETECT_ACTIVE_TOOL_PROBE")

--- a/macros/nozzle_clean.cfg
+++ b/macros/nozzle_clean.cfg
@@ -71,22 +71,12 @@ gcode:
         G1 F{cle_speed}
         M400    
         {% for n in range(5) %}
-            G1 X{cle_x + 2} Y{cle_y - 10}
-            G1 X{cle_x - 2} Y{cle_y - 12}
-            G1 X{cle_x + 2} Y{cle_y - 16}
-            G1 X{cle_x - 2} Y{cle_y - 20}
-            G1 X{cle_x + 2} Y{cle_y - 24}
-            G1 X{cle_x - 2} Y{cle_y - 28}
-            G1 X{cle_x + 2} Y{cle_y - 30}
-            G1 X{cle_x - 2} Y{cle_y - 32}
+            G1 X{cle_x + 3} Y{cle_y - 10}
+            G1 X{cle_x - 3} Y{cle_y - 20}
             G1 X{cle_x + 2} Y{cle_y - 32}
-            G1 X{cle_x - 2} Y{cle_y - 30}
-            G1 X{cle_x + 2} Y{cle_y - 28}
-            G1 X{cle_x - 2} Y{cle_y - 24}
-            G1 X{cle_x + 2} Y{cle_y - 20}
-            G1 X{cle_x - 2} Y{cle_y - 16}
-            G1 X{cle_x + 2} Y{cle_y - 12}
-            G1 X{cle_x - 2} Y{cle_y - 10}
+            G1 X{cle_x - 2} Y{cle_y - 32}
+            G1 X{cle_x + 3} Y{cle_y - 20}
+            G1 X{cle_x - 3} Y{cle_y - 10}
             G1 X{cle_x + 2} Y{cle_y - 32}
             G1 X{cle_x + 2} Y{cle_y - 10}
             G1 X{cle_x - 2} Y{cle_y - 32}

--- a/macros/offsets_adjust_record.cfg
+++ b/macros/offsets_adjust_record.cfg
@@ -35,19 +35,20 @@ gcode:
     {% if zr != 0.0 %}
         SET_GCODE_VARIABLE MACRO=_CURRENT_OFFSET  VARIABLE=zg  VALUE={ zr + printer["gcode_macro _CURRENT_OFFSET"].zg|float }
     {% endif %}
-    # M400
-
+    
     ## Overwrite the current offset with absolute offset, only if it is to reset the offset.
-    {% if xa == 0.0 %}
-        SET_GCODE_VARIABLE MACRO=_CURRENT_OFFSET  VARIABLE=xg  VALUE={ xa|float }
+    ## And only if there is no ongoing toolchanging.
+    {% if printer["gcode_macro _BEFORE_SELECT_TOOL"].toolchanging|int == 0 %}
+        {% if xa == 0.0 %}
+            SET_GCODE_VARIABLE MACRO=_CURRENT_OFFSET  VARIABLE=xg  VALUE={ xa|float }
+        {% endif %}
+        {% if ya == 0.0 %}
+            SET_GCODE_VARIABLE MACRO=_CURRENT_OFFSET  VARIABLE=yg  VALUE={ ya|float }
+        {% endif %}
+        {% if za == 0.0 %}
+            SET_GCODE_VARIABLE MACRO=_CURRENT_OFFSET  VARIABLE=zg  VALUE={ za|float }
+        {% endif %}
     {% endif %}
-    {% if ya == 0.0 %}
-        SET_GCODE_VARIABLE MACRO=_CURRENT_OFFSET  VARIABLE=yg  VALUE={ ya|float }
-    {% endif %}
-    {% if za == 0.0 %}
-        SET_GCODE_VARIABLE MACRO=_CURRENT_OFFSET  VARIABLE=zg  VALUE={ za|float }
-    {% endif %}
-    # M400
 
 #####################################################################
 #                        Working

--- a/macros/overwrite.cfg
+++ b/macros/overwrite.cfg
@@ -77,6 +77,7 @@ gcode:
     {% if printer.tools_calibrate.calibration_probe_inactive %}
         INITIALIZE_TOOLCHANGER
         _QUAD_GANTRY_LEVEL
+        G28
     {% else %}
         RESPOND TYPE=error MSG='CALIBRATION PROBE NOT DOCKED!!!'
         M84

--- a/macros/print_time_default.cfg
+++ b/macros/print_time_default.cfg
@@ -5,6 +5,19 @@
 [gcode_macro PRINT_START]
 gcode:
     RESPOND TYPE=echo MSG='PRINT_START...'
+    ## Variables ----------------------------------------------------
+    {% set center_x = printer["gcode_macro _home"].xh|float %}
+    {% set center_y = printer["gcode_macro _home"].yh|float %}
+    {% set nmcs = printer['gcode_macro _static_variable'].nm_ciculation_speed|default(0.0)|float %}
+    {% set nmes = printer['gcode_macro _static_variable'].nm_exhaust_speed|default(0.0)|float %}
+    {% set chamber_temp_threshold = printer['gcode_macro _static_variable'].chamber_temp_threshold|default(90)|int %}
+    {% set chanberfs = printer['gcode_macro _static_variable'].chamber_ciculation_speed|default(0.0)|float %}
+    {% set chamber_temp = printer['temperature_sensor Chamber'].temperature %}
+    {% set max_offset = printer['gcode_macro _static_variable'].thermo_expand_offset %}
+    {% set temp_high = printer['gcode_macro _static_variable'].thermo_expand_temp_high %}
+    {% set temp_low = printer['gcode_macro _static_variable'].thermo_expand_temp_low %}
+    {% set clean_threshold = printer['gcode_macro _static_variable'].clean_threshold %}
+    {% set clean_dock_x = printer['gcode_macro _static_variable'].clean_dock_x %}
     ## Quad gantry leveling -----------------------------------------
     {% if "xyz" in printer.toolhead.homed_axes %}
         G28 X Y
@@ -23,9 +36,6 @@ gcode:
     SET_HEATER_TEMPERATURE HEATER=heater_bed TARGET={params.BED_TEMP}
     RESPOND TYPE=echo MSG='{"Fan on..."}'
     {% if 'fan_generic fan_nevermore_stealthmax' in printer.configfile.config %}
-        {% set nmcs = printer['gcode_macro _static_variable'].nm_ciculation_speed|default(0.0)|float %}
-        {% set nmes = printer['gcode_macro _static_variable'].nm_exhaust_speed|default(0.0)|float %}
-        {% set chamber_temp_threshold = printer['gcode_macro _static_variable'].chamber_temp_threshold|default(90)|int %}
         {% if params.BED_TEMP|int > chamber_temp_threshold %}
             SET_FAN_SPEED FAN=fan_nevermore_stealthmax SPEED={nmcs}
         {% else %}
@@ -33,7 +43,6 @@ gcode:
         {% endif %}
     {% endif %}
     {% if 'fan_generic fan_chamber_heater' in printer.configfile.config %}
-        {% set chanberfs = printer['gcode_macro _static_variable'].chamber_ciculation_speed|default(0.0)|float %}
         {% if params.BED_TEMP|int > chamber_temp_threshold %}
             SET_FAN_SPEED FAN=fan_chamber_heater SPEED={chanberfs}
         {% endif %}
@@ -47,11 +56,10 @@ gcode:
     ## Final home ---------------------------------------------------
     T0
     M109 T0 S150                                            # Heat up to account for thermal expansion.
-    {% if printer["gcode_macro _home"].dock == True and printer['gcode_macro _static_variable'].clean_dock_x > 0 %}
-        G1 Z{printer['toolchanger'].params_min_z|float} F9000
-        _CLEAN_MID_PRINT
+    {% if printer["gcode_macro _home"].dock == True and clean_dock_x > 0 %}
         _CLEAN_MID_PRINT
     {% endif %}
+    _CLIENT_LINEAR_MOVE X={center_x} Y={center_y} F=9000 ABSOLUTE=1
     G28 Z                                                   # Homing
     ## Bed Mesh -----------------------------------------------------
     BED_MESH_CLEAR                                          # Unloading net beds
@@ -81,7 +89,7 @@ gcode:
         M104 T0 S0                                          # Else, turn T0 off
     {% endif %}
     ## Set toolhead need_clean flag ---------------------------------
-    {% if params.FIRST_LAYER_PRINT_SIZE|float < printer['gcode_macro _static_variable'].clean_threshold %}
+    {% if params.FIRST_LAYER_PRINT_SIZE|float < clean_threshold %}
         RESPOND TYPE=echo MSG='Small print job, no material setting needed'
     {% else %}
         {% for material in printer['toolchanger'].params_need_clean_materials %}
@@ -133,13 +141,8 @@ gcode:
         SKEW_PROFILE LOAD=calilantern_skew_profile          # Load skew compensation
     {% endif %}
     ## Account for frame thermal expansion --------------------------
-    {% if 'temperature_sensor Chamber' in printer.configfile.config and printer['gcode_macro _static_variable'].thermo_expand_temp_low > 0 %}
-        {% if printer['temperature_sensor Chamber'].temperature > printer['gcode_macro _static_variable'].thermo_expand_temp_low %}
-            ## Variables
-            {% set chamber_temp = printer['temperature_sensor Chamber'].temperature %}
-            {% set max_offset = printer['gcode_macro _static_variable'].thermo_expand_offset %}
-            {% set temp_high = printer['gcode_macro _static_variable'].thermo_expand_temp_high %}
-            {% set temp_low = printer['gcode_macro _static_variable'].thermo_expand_temp_low %}
+    {% if 'temperature_sensor Chamber' in printer.configfile.config and temp_low > 0 %}
+        {% if printer['temperature_sensor Chamber'].temperature > temp_low %}
             ## Calculations
             {% set z_offset = ((chamber_temp-temp_low)/(temp_high-temp_low)*max_offset)|round(3, 'common') %}
             ## Apply z-offset

--- a/macros/print_time_default.cfg
+++ b/macros/print_time_default.cfg
@@ -52,7 +52,7 @@ gcode:
         _CLEAN_MID_PRINT
         _CLEAN_MID_PRINT
     {% endif %}
-    G28                                                     # Homing
+    G28 Z                                                   # Homing
     ## Bed Mesh -----------------------------------------------------
     BED_MESH_CLEAR                                          # Unloading net beds
     {% if 'exclude_object' in printer.configfile.config and printer['exclude_object'].objects == null %}

--- a/macros/print_time_default.cfg
+++ b/macros/print_time_default.cfg
@@ -62,12 +62,6 @@ gcode:
     {% endif %}
     ## Set print temps ----------------------------------------------
     RESPOND TYPE=echo MSG='Set Print Temps...'
-    {% if "T0_TEMP" in params %}
-        M104 T0 S{ params.T0_TEMP }                         # If T0 is used, set it to print temp
-        SET_GCODE_VARIABLE  MACRO=T0  VARIABLE=print_temp  VALUE={params.T0_TEMP}
-    {% else %}
-        M104 T0 S0                                          # Else, turn T0 off
-    {% endif %}
     {% if "T1_TEMP" in params %}
         M104 T1 S{ params.T1_TEMP }                         # If T1 is used, set it to print temp
         SET_GCODE_VARIABLE  MACRO=T1  VARIABLE=print_temp  VALUE={params.T1_TEMP}
@@ -79,6 +73,12 @@ gcode:
     {% if "T3_TEMP" in params %}
         M104 T3 S{ params.T3_TEMP }                         # If T3 is used, set it to print temp
         SET_GCODE_VARIABLE  MACRO=T3  VARIABLE=print_temp  VALUE={params.T3_TEMP}
+    {% endif %}
+    {% if "T0_TEMP" in params %}
+        M109 T0 S{ params.T0_TEMP }                         # If T0 is used, get it to print temp before continue 
+        SET_GCODE_VARIABLE  MACRO=T0  VARIABLE=print_temp  VALUE={params.T0_TEMP}
+    {% else %}
+        M104 T0 S0                                          # Else, turn T0 off
     {% endif %}
     ## Set toolhead need_clean flag ---------------------------------
     {% if params.FIRST_LAYER_PRINT_SIZE|float < printer['gcode_macro _static_variable'].clean_threshold %}

--- a/macros/toolchanger.cfg
+++ b/macros/toolchanger.cfg
@@ -4,6 +4,7 @@
 #
 #--------------------------------------------------------------------
 [gcode_macro _BEFORE_SELECT_TOOL]
+variable_toolchanging: 0    # 0 = false; 1 = true
 gcode:
     # Custom pre toolchange gcode
     {% set next_tool = (params.TOOL|string)|default(none) %}
@@ -18,10 +19,12 @@ gcode:
             {% endif %}
         {% endif %}
     {% endif %}
-    ## Skew ---------------------------------------------------------
+    ## Skew
     {% if 'skew_correction' in printer.configfile.config and printer["gcode_macro _print_time"].printing|int == 1 %}
         SET_SKEW CLEAR=1                                    # Clear skew compensation
     {% endif %}
+    ## Set toolchange status to 1 (true)
+    SET_GCODE_VARIABLE MACRO=_BEFORE_SELECT_TOOL VARIABLE=toolchanging VALUE=1
 
 #--------------------------------------------------------------------
 [gcode_macro _TOOL_BEFORE_CHANGE]
@@ -175,11 +178,13 @@ gcode:
 [gcode_macro _AFTER_SELECT_TOOL]
 gcode:
     # Custom post toolchange gcode
-    ## Skew ---------------------------------------------------------
+    ## Skew
     {% if 'skew_correction' in printer.configfile.config and printer["gcode_macro _print_time"].printing|int == 1 %}
         SET_SKEW CLEAR=1                                    # Clear skew compensation
         SKEW_PROFILE LOAD=calilantern_skew_profile          # Load skew compensation
     {% endif %}
+    ## Set toolchange status to 0 (false)
+    SET_GCODE_VARIABLE MACRO=_BEFORE_SELECT_TOOL VARIABLE=toolchanging VALUE=0
 
 #--------------------------------------------------------------------
 ## Support Macros

--- a/macros/toolchanger.cfg
+++ b/macros/toolchanger.cfg
@@ -6,6 +6,18 @@
 [gcode_macro _BEFORE_SELECT_TOOL]
 gcode:
     # Custom pre toolchange gcode
+    {% set next_tool = (params.TOOL|string)|default(none) %}
+    {% if printer["gcode_macro _print_time"].printing|int == 1 %}
+        {% if next_tool != none %}
+            {% set next_macro = "gcode_macro T" ~ next_tool %}
+            ## Reset extruder
+            G92 E0
+            # Start heating next tool
+            {% if printer[next_macro].print_temp > 0 %}
+                M104 T{next_tool} S{printer[next_macro].print_temp|int}
+            {% endif %}
+        {% endif %}
+    {% endif %} 
 
 #--------------------------------------------------------------------
 [gcode_macro _TOOL_BEFORE_CHANGE]
@@ -16,19 +28,6 @@ gcode:
     {% if printer["gcode_macro T" + tool.tool_number|string ] %}
         SET_GCODE_VARIABLE MACRO=T{tool.tool_number} VARIABLE=color VALUE="''"
     {% endif %}
-    ## Reset extruder
-    G92 E0
-    ## Start heating next tool early
-    {% if printer["gcode_macro _print_time"].printing|int == 1 %}
-        {% set next_tool = printer.toolchanger.tool_next|default(none) %}
-        {% if next_tool != none %}
-            {% set next_macro = "gcode_macro T" ~ next_tool %}
-            {% if printer[next_macro].print_temp > 0 %}
-                # Start heating next tool
-                M104 T{next_tool} S{printer[next_macro].print_temp|int}
-            {% endif %}
-        {% endif %}
-    {% endif %} 
     
 #--------------------------------------------------------------------
 [gcode_macro _TOOL_DROPOFF]

--- a/macros/toolchanger.cfg
+++ b/macros/toolchanger.cfg
@@ -12,7 +12,7 @@ gcode:
             {% set next_macro = "gcode_macro T" ~ next_tool %}
             ## Reset extruder
             G92 E0
-            # Start heating next tool
+            ## Start heating next tool
             {% if printer[next_macro].print_temp > 0 %}
                 M104 T{next_tool} S{printer[next_macro].print_temp|int}
             {% endif %}

--- a/macros/toolchanger.cfg
+++ b/macros/toolchanger.cfg
@@ -18,6 +18,17 @@ gcode:
     {% endif %}
     ## Reset extruder
     G92 E0
+    ## Start heating next tool early
+    {% if printer["gcode_macro _print_time"].printing|int == 1 %}
+        {% set next_tool = printer.toolchanger.tool_next|default(none) %}
+        {% if next_tool != none %}
+            {% set next_macro = "gcode_macro T" ~ next_tool %}
+            {% if printer[next_macro].print_temp > 0 %}
+                # Start heating next tool
+                M104 T{next_tool} S{printer[next_macro].print_temp|int}
+            {% endif %}
+        {% endif %}
+    {% endif %} 
     
 #--------------------------------------------------------------------
 [gcode_macro _TOOL_DROPOFF]

--- a/macros/toolchanger.cfg
+++ b/macros/toolchanger.cfg
@@ -26,8 +26,8 @@ gcode:
 #--------------------------------------------------------------------
 [gcode_macro _TOOL_BEFORE_CHANGE]
 gcode:
-    {% set tn   = params.TN|string %}
-    {% set tool = printer['tool ' + tn] %}
+    {% set tn     = params.TN|string %}
+    {% set tool   = printer['tool ' + tn] %}
     ## LED setting
     {% if printer["gcode_macro T" + tool.tool_number|string ] %}
         SET_GCODE_VARIABLE MACRO=T{tool.tool_number} VARIABLE=color VALUE="''"
@@ -48,9 +48,14 @@ gcode:
     {% set max_z  = printer.configfile.config["stepper_z"]["position_max"]|float %}
     {% set min_z  = tool.params_min_z|float %}
     {% set z_hop  = tool.params_z_hop|default(1.0)|float %}
+    {% set cur_y  = printer.toolhead.position[1]|float %}
     {% set cur_z  = printer.toolhead.position[2]|float %}
-    ## Move to the dock
     G90
+    ## Safety move
+    {% if cur_y < safe_y %}
+        _CLIENT_LINEAR_MOVE Y={safe_y} F={fast} ABSOLUTE=1
+    {% endif %}
+    ## Move to the dock
     {% if cur_z < min_z %}
         _CLIENT_LINEAR_MOVE X={x} Y={safe_y} Z={min_z+z_hop} F={fast} ABSOLUTE=1
     {% else %}

--- a/macros/toolchanger.cfg
+++ b/macros/toolchanger.cfg
@@ -17,7 +17,11 @@ gcode:
                 M104 T{next_tool} S{printer[next_macro].print_temp|int}
             {% endif %}
         {% endif %}
-    {% endif %} 
+    {% endif %}
+    ## Skew ---------------------------------------------------------
+    {% if 'skew_correction' in printer.configfile.config and printer["gcode_macro _print_time"].printing|int == 1 %}
+        SET_SKEW CLEAR=1                                    # Clear skew compensation
+    {% endif %}
 
 #--------------------------------------------------------------------
 [gcode_macro _TOOL_BEFORE_CHANGE]
@@ -166,6 +170,11 @@ gcode:
 [gcode_macro _AFTER_SELECT_TOOL]
 gcode:
     # Custom post toolchange gcode
+    ## Skew ---------------------------------------------------------
+    {% if 'skew_correction' in printer.configfile.config and printer["gcode_macro _print_time"].printing|int == 1 %}
+        SET_SKEW CLEAR=1                                    # Clear skew compensation
+        SKEW_PROFILE LOAD=calilantern_skew_profile          # Load skew compensation
+    {% endif %}
 
 #--------------------------------------------------------------------
 ## Support Macros

--- a/macros/toolchanger.cfg
+++ b/macros/toolchanger.cfg
@@ -95,12 +95,15 @@ gcode:
         {% endif %}
         ## Restore the position with smooth rounded move
         {% if 'Z' in restore_position %}
+            RESPOND TYPE=echo MSG='TC Restore Z'
             _CLIENT_LINEAR_MOVE Z={restore_position.Z} F={fast} ABSOLUTE=1
         {% endif %}
         {% if 'X' in restore_position %}
+            RESPOND TYPE=echo MSG='TC Restore X'
             _CLIENT_LINEAR_MOVE X={restore_position.X} F={fast} ABSOLUTE=1
         {% endif %}
         {% if 'Y' in restore_position %}
+            RESPOND TYPE=echo MSG='TC Restore Y'
             _CLIENT_LINEAR_MOVE Y={restore_position.Y} F={fast} ABSOLUTE=1
         {% endif %}
     {% else %}

--- a/scripts/misschanger_settings.cfg
+++ b/scripts/misschanger_settings.cfg
@@ -4,26 +4,25 @@
 #
 #--------------------------------------------------------------------
 [tool_probe_endstop]
-crash_mintime: 2              # seconds to wait before announcing a crash 
+crash_mintime: 3              # seconds to wait before announcing a crash 
 crash_gcode:
     _TOOLCHANGER_CRASH
 
 #--------------------------------------------------------------------
 [tools_calibrate]
 pin: PG10                     # probe pin
-travel_speed: 20              # mm/s to travel sideways for XY probing
+travel_speed: 20              # The speed (in mm/sec) to retract between probes
 spread: 6                     # mm to travel down from top for XY probing
-lower_z: 1.0                  # The speed (in mm/sec) to move tools down onto the probe
-speed: 1.5                    # The speed (in mm/sec) to retract between probes
-lift_speed: 5.0               # The speed (in mm/sec) to retract between probes
+lower_z: 0.25                 # Distance to lower the nozzle to hit. (0 -> slides over | 3-4 -> hits silicone sock)
+speed: 1.5                    # The speed (in mm/sec) during probes
+lift_speed: 5.0               # The speed (in mm/sec) to raise Z
 final_lift_z: 3               # Z Lift after probing done, should be greater than any Z variance between tools
 samples: 5                    # Number of sample
-samples_result: median        # median, average
+samples_result: median        # median / average
 sample_retract_dist: 1        # Sample retract distance        
-samples_tolerance: 0.0100     # UPDATE THIS WITH YOUR PRINTER
+samples_tolerance: 0.0200     # UPDATE THIS WITH YOUR PRINTER
 samples_tolerance_retries: 10 # Number of retries on failures
-trigger_to_bottom_z: 0.3575   # Decrease -> Higher nozzle
-
+trigger_to_bottom_z: 0.4325   # Decrease -> Higher nozzle
 #--------------------------------------------------------------------
 [toolchanger]
 t_command_restore_axis:       # The axis to restore, by default
@@ -32,11 +31,11 @@ on_axis_not_homed: abort      # When required axis are not homed. Option: 'abort
 transfer_fan_speed: True      # fan speed is transferred during toolchange
 params_safe_y: 125            # The closest toward the front that the toolhead can go without coliding with the docked toolhead(s)
 params_close_y: 50            # The closest toward the front that the toolhead-carrier can go without coliding with the docked toolhead(s)
-params_min_z: 40              # The lowest z position that tool-changing can happen
+params_min_z: 30              # The lowest z position that tool-changing can happen
 params_max_z: 250             # The highest z position that tool-changing can happen
 params_fast_speed: 10000      # (1500 = 40mm/s) The speed to travel to the first point in the tool-change path
 params_path_speed:  5000      # (1500 = 40mm/s) The max speed to travel during the tool-change path
-params_z_hop: 1.0             # The amount of z-hop during toolchange (in mm). Default is 1.0 mm
+params_z_hop: 2.0             # The amount of z-hop during toolchange (in mm). Default is 1.0 mm
 
 ## Materials that tend to have blobs accumulation (of itself or other materials) on the nozzle.
 params_need_clean_materials: ['PETG', 'FLEX']
@@ -50,16 +49,24 @@ params_sb_misschanger_path: [{'x':0,       'y':0,      'f':1.00,    'd':1},
                              {'x':0,       'y':-65,    'f':0.75,    'd':0},    # Wiggle...
                              {'x':0,       'y':-60,    'f':0.70,    'd':0},    # Wiggle...
                              {'x':0,       'y':-70,    'f':0.70,    'd':1},
-                             {'x':-0.50,   'y':-62,    'f':0.45,    'd':0},    # Wiggle...
-                             {'x':-0.50,   'y':-67,    'f':0.45,    'd':0},    # Wiggle...
-                             {'x':-0.50,   'y':-65,    'f':0.45,    'd':0},    # Wiggle...
-                             {'x':-0.50,   'y':-75,    'f':0.45,    'd':0},    # Wiggle...
-                             {'x':-0.50,   'y':-70,    'f':0.40,    'd':0},    # Wiggle...
-                             {'x':-0.50,   'y':-80,    'f':0.30,    'd':0},
+                             {'x':0,       'y':-62,    'f':0.45,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-67,    'f':0.45,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-65,    'f':0.45,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-75,    'f':0.45,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-70,    'f':0.40,    'd':0},
                              {'x':0,       'y':-80,    'f':0.30,    'd':1},
-                             {'x':-6.0,    'y':-80,    'f':0.20,    'd':1},  
-                             {'x':-6.0,    'y':-70,    'f':0.30,    'd':1},
-                             {'x':-6.0,    'y':-40,    'f':1.00,    'd':1}]
+                             {'x':0,       'y':-80.50, 'f':0.80,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-79.50, 'f':0.80,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-80,    'f':0.30,    'd':0},    # Wiggle...
+                             {'x':+0.50,   'y':-80,    'f':0.80,    'd':0},    # Wiggle...
+                             {'x':-0.50,   'y':-80,    'f':0.80,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-80,    'f':0.30,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-80.50, 'f':0.80,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-79.50, 'f':0.80,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-80,    'f':0.30,    'd':0},    # Wiggle...
+                             {'x':-5.50,   'y':-80,    'f':0.20,    'd':1},  
+                             {'x':-5.50,   'y':-70,    'f':0.30,    'd':1},
+                             {'x':-5.50,   'y':-40,    'f':1.00,    'd':1}]
 
 initialize_on: manual
 
@@ -69,24 +76,20 @@ initialize_gcode:
 
 before_change_gcode: 
     {% if tool.name %}
-        # RESPOND TYPE=echo MSG='Before changing {tool.name}'
         _TOOL_BEFORE_CHANGE TN={tool.name|replace('tool ', '', 1)}
     {% endif %}
 
 after_change_gcode: 
     {% if tool.name %}
-        # RESPOND TYPE=echo MSG='After changing {tool.name}'
         _TOOL_AFTER_CHANGE TN={tool.name|replace('tool ', '', 1)}
     {% endif %}
 
 dropoff_gcode:
     {% if tool.name %}
-        # RESPOND TYPE=echo MSG='Dropping off {tool.name}'
         _TOOL_DROPOFF TN={tool.name|replace('tool ', '', 1)}
     {% endif %}
 
 pickup_gcode:
     {% if tool.name %}
-        # RESPOND TYPE=echo MSG='Picking up {tool.name}'
         _TOOL_PICKUP TN={tool.name|replace('tool ', '', 1)}
     {% endif %}


### PR DESCRIPTION
# Overview.
Bug fixes, optimisations, and Orca support.

# Changes:
- klipper/extras/toolchanger.py
    - Bug fix.
- macros/nozzle_clean.cfg
    - Reduce the aggressive scrub, to avoid step skipping.
- macros/offsets_adjust_record.cfg
    - Bug fix, where tool-change cause `save_babies` to be reset.
- macros/overwrite.cfg
    - Add mandatory re-home after QGL, for accuracy.
- macros/print_time_default.cfg
    - `PRINT_START` now wait for T0 to fully heat-up (if it used). This change is for Orca Slicer.
- macros/toolchanger.cfg
    - Account for skew, if it is enabled. **NOTE:** The skew profile must be named "**calilantern_skew_profile**"
- scripts/misschanger_settings.cfg
    - Update starting config with more reliable tool-change. **MUST BE UPDATED MANUALLY.**
