### PR TITLE
Clean-up and improvements

### DIFF
--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -95,8 +95,7 @@ class ToolsCalibrate:
         toolhead.set_position(position)
         return [center_x, center_y, center_z]
 
-    cmd_TOOL_LOCATE_SENSOR_help = ("Locate the tool calibration sensor, "
-                                   "use with tool 0.")
+    cmd_TOOL_LOCATE_SENSOR_help = ("Locate the tool calibration sensor, use with tool 0.")
 
     def cmd_TOOL_LOCATE_SENSOR(self, gcmd):
         self.last_result = self.locate_sensor(gcmd)
@@ -110,12 +109,6 @@ class ToolsCalibrate:
             raise gcmd.error("No recorded sensor location, please run TOOL_LOCATE_SENSOR first")
         location = self.locate_sensor(gcmd)
         self.last_result = [location[i] - self.sensor_location[i] for i in range(3)]
-
-        # self.gcode.respond_info("Paste into your config file for tool:\n"
-        #                         "gcode_x_offset: %.6f\n"
-        #                         "gcode_y_offset: %.6f\n"
-        #                         "gcode_z_offset: %.6f\n"
-        #                         % (self.last_result[0], self.last_result[1], self.last_result[2]))
 
     cmd_TOOL_CALIBRATE_SAVE_TOOL_OFFSET_help = "Save tool offset calibration to config"
 
@@ -146,13 +139,8 @@ class ToolsCalibrate:
         probe_session.end_probe_session()
         # calculate z-offset
         z_offset = probe_z - nozzle_z + self.trigger_to_bottom_z
-        
+        # record the data
         self.last_probe_offset = z_offset
-        # self.gcode.respond_info(
-        #     "%s: z_offset: %.3f\n"
-        #     "The SAVE_CONFIG command will update the printer config file\n"
-        #     "with the above and restart the printer." 
-        #     % (self.probe_name, z_offset))
         config_name = gcmd.get("PROBE", default=self.probe_name)
         if config_name:
             configfile = self.printer.lookup_object('configfile')
@@ -226,7 +214,6 @@ class PrinterProbeMultiAxis:
             if "Timeout during endstop homing" in reason:
                 reason += HINT_TIMEOUT
             raise self.printer.command_error(reason)
-        # self.gcode.respond_info("probe at %.3f,%.3f is z=%.6f"
         self.gcode.respond_info("Probe made contact at %.6f,%.6f,%.6f"% (epos[0], epos[1], epos[2]))
         return epos[:3]
 
@@ -323,8 +310,7 @@ class ProbeEndstopWrapper:
         pin_params = ppins.lookup_pin(pin, can_invert=True, can_pullup=True)
         mcu = pin_params['chip']
         self.mcu_endstop = mcu.setup_pin('endstop', pin_params)
-        self.printer.register_event_handler('klippy:mcu_identify',
-                                            self._handle_mcu_identify)
+        self.printer.register_event_handler('klippy:mcu_identify', self._handle_mcu_identify)
         # Wrappers
         self.get_mcu = self.mcu_endstop.get_mcu
         self.add_stepper = self.mcu_endstop.add_stepper

--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -148,7 +148,7 @@ class ToolsCalibrate:
         # back to start pos
         toolhead.move(start_pos, self.travel_speed)
         toolhead.set_position(start_pos)
-        return self.last_probe_offset
+        # return self.last_probe_offset
 
     def get_status(self, eventtime):
         return {'last_result': self.last_result,

--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -79,14 +79,12 @@ class ToolsCalibrate:
         downPos = self.probe_multi_axis.run_probe("z-", gcmd, samples=1)
         center_x, center_y = self.calibrate_xy(toolhead, downPos, gcmd, samples=1)
 
-        toolhead.manual_move([None, None, downPos[2] + self.lift_z],
-                             self.lift_speed)
+        toolhead.manual_move([None, None, downPos[2] + self.lift_z], self.lift_speed)
         toolhead.manual_move([center_x, center_y, None], self.travel_speed)
         center_z = self.probe_multi_axis.run_probe("z-", gcmd, speed_ratio=0.5)[2]
+
         # Now redo X and Y, since we have a more accurate center.
-        center_x, center_y = self.calibrate_xy(toolhead,
-                                               [center_x, center_y, center_z],
-                                               gcmd)
+        center_x, center_y = self.calibrate_xy(toolhead, [center_x, center_y, center_z], gcmd)
 
         # rest above center
         position[0] = center_x
@@ -103,8 +101,7 @@ class ToolsCalibrate:
     def cmd_TOOL_LOCATE_SENSOR(self, gcmd):
         self.last_result = self.locate_sensor(gcmd)
         self.sensor_location = self.last_result
-        self.gcode.respond_info("Sensor location at %.6f,%.6f,%.6f"
-                                % (self.last_result[0], self.last_result[1], self.last_result[2]))
+        self.gcode.respond_info("Sensor location at %.6f,%.6f,%.6f" % (self.last_result[0], self.last_result[1], self.last_result[2]))
 
     cmd_TOOL_CALIBRATE_TOOL_OFFSET_help = "Calibrate current tool offset relative to tool 0"
 
@@ -141,21 +138,21 @@ class ToolsCalibrate:
         toolhead = self.printer.lookup_object('toolhead')
         probe = self.printer.lookup_object(self.probe_name)
         start_pos = toolhead.get_position()
-        nozzle_z = self.probe_multi_axis.run_probe("z-", gcmd, speed_ratio=0.5)[
-            2]
+        nozzle_z = self.probe_multi_axis.run_probe("z-", gcmd, speed_ratio=0.5)[2]
         # now move down with the tool probe
         probe_session = probe.start_probe_session(gcmd)
         probe_session.run_probe(gcmd)
         probe_z = probe_session.pull_probed_results()[0][2]
         probe_session.end_probe_session()
-
+        # calculate z-offset
         z_offset = probe_z - nozzle_z + self.trigger_to_bottom_z
+        
         self.last_probe_offset = z_offset
-        self.gcode.respond_info(
-            "%s: z_offset: %.3f\n"
-            "The SAVE_CONFIG command will update the printer config file\n"
-            "with the above and restart the printer." 
-            % (self.probe_name, z_offset))
+        # self.gcode.respond_info(
+        #     "%s: z_offset: %.3f\n"
+        #     "The SAVE_CONFIG command will update the printer config file\n"
+        #     "with the above and restart the printer." 
+        #     % (self.probe_name, z_offset))
         config_name = gcmd.get("PROBE", default=self.probe_name)
         if config_name:
             configfile = self.printer.lookup_object('configfile')

--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -148,6 +148,7 @@ class ToolsCalibrate:
         # back to start pos
         toolhead.move(start_pos, self.travel_speed)
         toolhead.set_position(start_pos)
+        return self.last_probe_offset
 
     def get_status(self, eventtime):
         return {'last_result': self.last_result,
@@ -229,11 +230,9 @@ class PrinterProbeMultiAxis:
         if 'axis_minimum' not in kin_status or 'axis_minimum' not in kin_status:
             raise self.gcode.error("Tools calibrate only works with cartesian kinematics")
         if sense > 0:
-            pos[axis] = min(pos[axis] + max_distance,
-                            kin_status['axis_maximum'][axis])
+            pos[axis] = min(pos[axis] + max_distance, kin_status['axis_maximum'][axis])
         else:
-            pos[axis] = max(pos[axis] - max_distance,
-                            kin_status['axis_minimum'][axis])
+            pos[axis] = max(pos[axis] - max_distance, kin_status['axis_minimum'][axis])
         return pos
 
     def _move(self, coord, speed):

--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -114,11 +114,11 @@ class ToolsCalibrate:
         location = self.locate_sensor(gcmd)
         self.last_result = [location[i] - self.sensor_location[i] for i in range(3)]
 
-        self.gcode.respond_info("Paste into your config file for tool:\n"
-                                "gcode_x_offset: %.6f\n"
-                                "gcode_y_offset: %.6f\n"
-                                "gcode_z_offset: %.6f\n"
-                                % (self.last_result[0], self.last_result[1], self.last_result[2]))
+        # self.gcode.respond_info("Paste into your config file for tool:\n"
+        #                         "gcode_x_offset: %.6f\n"
+        #                         "gcode_y_offset: %.6f\n"
+        #                         "gcode_z_offset: %.6f\n"
+        #                         % (self.last_result[0], self.last_result[1], self.last_result[2]))
 
     cmd_TOOL_CALIBRATE_SAVE_TOOL_OFFSET_help = "Save tool offset calibration to config"
 

--- a/macros/homing.cfg
+++ b/macros/homing.cfg
@@ -107,9 +107,10 @@ gcode:
     _CLIENT_LINEAR_MOVE Z=10 F=1500 ABSOLUTE=1
     {% set tool = printer.toolchanger.tool %}
     {% if tool %}
-        {% set gcode_z_offset = printer[tool].gcode_z_offset %}
+        # {% set gcode_z_offset = printer[tool].gcode_z_offset %}
         {% set probe_z_offset = printer.tool_probe_endstop.active_tool_probe_z_offset %}
-        SET_KINEMATIC_POSITION Z={10.0 + probe_z_offset|float + 2*gcode_z_offset|float}
+        # SET_KINEMATIC_POSITION Z={10.0 + probe_z_offset|float + 2*gcode_z_offset|float}
+        SET_KINEMATIC_POSITION Z={10.0 + probe_z_offset|float}
         _CLIENT_LINEAR_MOVE Z=10 F=1500 ABSOLUTE=1
     {% endif %}
 

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -72,7 +72,17 @@ gcode:
 gcode:
     TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
     M400
-
+#--------------------------------------------------------------------
+[gcode_macro _CALIBRATE_PROBE_OTHER_OFFSET]
+gcode:
+    ## Variables
+    {% set tools  = printer.toolchanger.tool_numbers %}
+    {% set z_off = printer['tools_calibrate'].last_probe_offset|round(6, 'common') %}
+    ## z-offset
+    RESPOND TYPE=echo MSG='z_offset = {z_off}'
+    {% for tool in tools[1:] %}
+        TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool_probe T{tool}" ATTRIBUTE=z_offset VALUE="{z_off}"
+    {% endfor %}
 #--------------------------------------------------------------------
 [gcode_macro _CALIBRATE_OFFSETS]
 gcode:
@@ -95,14 +105,10 @@ gcode:
         G28
         _CALIBRATE_MOVE_OVER_PROBE
         TOOL_LOCATE_SENSOR
-        ## T0 z-offset
+        ## z-offset
         {% if abs_z == 0 %}
             _CALIBRATE_PROBE_0_OFFSET
-            {% set z_off = printer['tools_calibrate'].last_probe_offset|round(6, 'common') %}
-            RESPOND TYPE=echo MSG='z_offset = {z_off}'
-            {% for tool in tools[1:] %}
-                TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool_probe T{tool}" ATTRIBUTE=z_offset VALUE="{z_off}"
-            {% endfor %}
+            _CALIBRATE_PROBE_OTHER_OFFSET
         {% endif %}
 
         ## Single tool

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -92,6 +92,7 @@ gcode:
         ## T0 z-offset
         {% if abs_z == 0 %}
             TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
+            M400
             {% for tool in tools[1:] %}
                 {% set z_off = printer['tools_calibrate'].last_probe_offset|round(6, 'common') %}
                 TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool_probe T{tool}" ATTRIBUTE=z_offset VALUE="{z_off}"

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -107,14 +107,14 @@ gcode:
         TOOL_LOCATE_SENSOR
         ## z-offset
         {% if abs_z == 0 %}
-            # _CALIBRATE_PROBE_0_OFFSET
-            # _CALIBRATE_PROBE_OTHER_OFFSET
-            TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
-            {% set z_off = printer['tools_calibrate'].last_probe_offset|round(6, 'common') %}
-            ## z-offset
-            RESPOND TYPE=echo MSG='z_offset = {z_off}'
-            {% for tool in tools[1:] %}
-                TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool_probe T{tool}" ATTRIBUTE=z_offset VALUE="{z_off}"
+            _CALIBRATE_PROBE_0_OFFSET
+            _CALIBRATE_PROBE_OTHER_OFFSET
+            # TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
+            # {% set z_off = printer['tools_calibrate'].last_probe_offset|round(6, 'common') %}
+            # ## z-offset
+            # RESPOND TYPE=echo MSG='z_offset = {z_off}'
+            # {% for tool in tools[1:] %}
+            #     TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool_probe T{tool}" ATTRIBUTE=z_offset VALUE="{z_off}"
     {% endfor %}
         {% endif %}
 

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -92,6 +92,10 @@ gcode:
         ## T0 z-offset
         {% if abs_z == 0 %}
             TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
+            {% for tool in tools[1:] %}
+                {% set z_off = printer['tools_calibrate'].last_probe_offset|round(6, 'common') %}
+                TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool_probe T{tool}" ATTRIBUTE=z_offset VALUE="{z_off}"
+            {% endfor %}
         {% endif %}
 
         ## Single tool
@@ -107,9 +111,6 @@ gcode:
             TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_x_offset VALUE="{% raw %}{x:0.6f}{% endraw %}"
             TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_y_offset VALUE="{% raw %}{y:0.6f}{% endraw %}"
             TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_z_offset VALUE="{% raw %}{z:0.6f}{% endraw %}"
-            # {% if abs_z == 0 %}
-            #     TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{params.TOOL}"
-            # {% endif %}
         {% endif %}
         
         ## All tools
@@ -126,10 +127,7 @@ gcode:
                 TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_x_offset VALUE="{% raw %}{x:0.6f}{% endraw %}"
                 TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_y_offset VALUE="{% raw %}{y:0.6f}{% endraw %}"
                 TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_z_offset VALUE="{% raw %}{z:0.6f}{% endraw %}"
-                # {% if abs_z == 0 %}
-                #     TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{tool}"
-                # {% endif %}
-            {% endfor %}             
+            {% endfor %}
         {% endif %}
         
         ## Finishing moves

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -68,6 +68,12 @@ gcode:
 #                        Hidden Worker
 #####################################################################
 #--------------------------------------------------------------------
+[gcode_macro _CALIBRATE_PROBE_0_OFFSET]
+gcode:
+    TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
+    M400
+
+#--------------------------------------------------------------------
 [gcode_macro _CALIBRATE_OFFSETS]
 gcode:
     ## Variables
@@ -91,8 +97,7 @@ gcode:
         TOOL_LOCATE_SENSOR
         ## T0 z-offset
         {% if abs_z == 0 %}
-            TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
-            M400
+            _CALIBRATE_PROBE_0_OFFSET
             {% for tool in tools[1:] %}
                 {% set z_off = printer['tools_calibrate'].last_probe_offset|round(6, 'common') %}
                 TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool_probe T{tool}" ATTRIBUTE=z_offset VALUE="{z_off}"

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -62,7 +62,7 @@ gcode:
         {% endif %}
     {% endif %}
     ## Finishing message
-    RESPOND TYPE=echo MSG='The SAVE_CONFIG command will update the printer config file\nwith the above and restart the printer.'
+    RESPOND TYPE=echo MSG='The SAVE_CONFIG command will update the printer config file with the above and restart the printer.'
 
 #####################################################################
 #                        Hidden Worker

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -107,8 +107,15 @@ gcode:
         TOOL_LOCATE_SENSOR
         ## z-offset
         {% if abs_z == 0 %}
-            _CALIBRATE_PROBE_0_OFFSET
-            _CALIBRATE_PROBE_OTHER_OFFSET
+            # _CALIBRATE_PROBE_0_OFFSET
+            # _CALIBRATE_PROBE_OTHER_OFFSET
+            TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
+            {% set z_off = printer['tools_calibrate'].last_probe_offset|round(6, 'common') %}
+            ## z-offset
+            RESPOND TYPE=echo MSG='z_offset = {z_off}'
+            {% for tool in tools[1:] %}
+                TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool_probe T{tool}" ATTRIBUTE=z_offset VALUE="{z_off}"
+    {% endfor %}
         {% endif %}
 
         ## Single tool

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -98,8 +98,9 @@ gcode:
         ## T0 z-offset
         {% if abs_z == 0 %}
             _CALIBRATE_PROBE_0_OFFSET
+            {% set z_off = printer['tools_calibrate'].last_probe_offset|round(6, 'common') %}
+            RESPOND TYPE=echo MSG='z_offset = {z_off}'
             {% for tool in tools[1:] %}
-                {% set z_off = printer['tools_calibrate'].last_probe_offset|round(6, 'common') %}
                 TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool_probe T{tool}" ATTRIBUTE=z_offset VALUE="{z_off}"
             {% endfor %}
         {% endif %}

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -62,7 +62,7 @@ gcode:
         {% endif %}
     {% endif %}
     ## Finishing message
-    RESPOND TYPE=echo MSG='{"The SAVE_CONFIG command will update the printer config file\nwith the above and restart the printer."}'
+    RESPOND TYPE=echo MSG='The SAVE_CONFIG command will update the printer config file\nwith the above and restart the printer.'
 
 #####################################################################
 #                        Hidden Worker

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -61,6 +61,8 @@ gcode:
             RESPOND TYPE=error MSG='No tool selected ("A" / "a" / "0" / "1" / etc.)'
         {% endif %}
     {% endif %}
+    ## Finishing message
+    RESPOND TYPE=echo MSG='{"The SAVE_CONFIG command will update the printer config file\nwith the above and restart the printer."}'
 
 #####################################################################
 #                        Hidden Worker
@@ -91,6 +93,7 @@ gcode:
         {% if abs_z == 0 %}
             TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
         {% endif %}
+
         ## Single tool
         {% if params.TOOL != null and params.TOOL != "0" and params.TOOL != "a" and params.TOOL != "A" %}
             SELECT_TOOL T={params.TOOL}  RESTORE_AXIS=XYZ
@@ -104,9 +107,9 @@ gcode:
             TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_x_offset VALUE="{% raw %}{x:0.6f}{% endraw %}"
             TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_y_offset VALUE="{% raw %}{y:0.6f}{% endraw %}"
             TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool T{params.TOOL}" ATTRIBUTE=gcode_z_offset VALUE="{% raw %}{z:0.6f}{% endraw %}"
-            {% if abs_z == 0 %}
-                TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{params.TOOL}"
-            {% endif %}
+            # {% if abs_z == 0 %}
+            #     TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{params.TOOL}"
+            # {% endif %}
         {% endif %}
         
         ## All tools
@@ -123,9 +126,9 @@ gcode:
                 TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_x_offset VALUE="{% raw %}{x:0.6f}{% endraw %}"
                 TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_y_offset VALUE="{% raw %}{y:0.6f}{% endraw %}"
                 TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_z_offset VALUE="{% raw %}{z:0.6f}{% endraw %}"
-                {% if abs_z == 0 %}
-                    TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{tool}"
-                {% endif %}
+                # {% if abs_z == 0 %}
+                #     TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{tool}"
+                # {% endif %}
             {% endfor %}             
         {% endif %}
         

--- a/macros/tool_calibrate.cfg
+++ b/macros/tool_calibrate.cfg
@@ -47,6 +47,7 @@ gcode:
     {% if params.TOOL != null and printer['quad_gantry_level'].applied == True and "xyz" in printer.toolhead.homed_axes %}
         _CHECK_PROBE
         _CALIBRATE_OFFSETS TOOL={params.TOOL}
+        _CALIBRATE_PROBE_OTHER_OFFSET
     {% else %}
         {% if printer['quad_gantry_level'].applied == False %}
             RESPOND TYPE=error MSG='Gantry is not LEVELED...'
@@ -67,11 +68,6 @@ gcode:
 #####################################################################
 #                        Hidden Worker
 #####################################################################
-#--------------------------------------------------------------------
-[gcode_macro _CALIBRATE_PROBE_0_OFFSET]
-gcode:
-    TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
-    M400
 #--------------------------------------------------------------------
 [gcode_macro _CALIBRATE_PROBE_OTHER_OFFSET]
 gcode:
@@ -107,15 +103,7 @@ gcode:
         TOOL_LOCATE_SENSOR
         ## z-offset
         {% if abs_z == 0 %}
-            _CALIBRATE_PROBE_0_OFFSET
-            _CALIBRATE_PROBE_OTHER_OFFSET
-            # TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
-            # {% set z_off = printer['tools_calibrate'].last_probe_offset|round(6, 'common') %}
-            # ## z-offset
-            # RESPOND TYPE=echo MSG='z_offset = {z_off}'
-            # {% for tool in tools[1:] %}
-            #     TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="tool_probe T{tool}" ATTRIBUTE=z_offset VALUE="{z_off}"
-    {% endfor %}
+            TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
         {% endif %}
 
         ## Single tool

--- a/scripts/misschanger_settings.cfg
+++ b/scripts/misschanger_settings.cfg
@@ -20,6 +20,7 @@ final_lift_z: 3               # Z Lift after probing done, should be greater tha
 samples: 5                    # Number of sample
 samples_result: median        # median / average
 sample_retract_dist: 1        # Sample retract distance        
+samples_tolerance: 0.0075     # UPDATE THIS WITH YOUR PRINTER
 samples_tolerance_retries: 10 # Number of retries on failures
 trigger_to_bottom_z: 0.3225   # Decrease -> Higher nozzle. 
                               #    Used in trigger calibration calculations.

--- a/scripts/misschanger_settings.cfg
+++ b/scripts/misschanger_settings.cfg
@@ -10,7 +10,7 @@ crash_gcode:
 
 #--------------------------------------------------------------------
 [tools_calibrate]
-pin: PG10                     # probe pin
+pin: PG10                     # probe pin, TO BE UPDATED
 travel_speed: 20              # The speed (in mm/sec) to retract between probes
 spread: 6                     # mm to travel down from top for XY probing
 lower_z: 0.25                 # Distance to lower the nozzle to hit. (0 -> slides over | 3-4 -> hits silicone sock)
@@ -20,12 +20,14 @@ final_lift_z: 3               # Z Lift after probing done, should be greater tha
 samples: 5                    # Number of sample
 samples_result: median        # median / average
 sample_retract_dist: 1        # Sample retract distance        
-samples_tolerance: 0.0200     # UPDATE THIS WITH YOUR PRINTER
 samples_tolerance_retries: 10 # Number of retries on failures
-trigger_to_bottom_z: 0.4325   # Decrease -> Higher nozzle
+trigger_to_bottom_z: 0.3225   # Decrease -> Higher nozzle. 
+                              #    Used in trigger calibration calculations.
+                              #    Defines Z distance from calibration probe *trigger* to mechanical bottom out.
+                              #    Similar to the distance from when your keyboard key registers a hit, to where it actually hits the bottom.
 #--------------------------------------------------------------------
 [toolchanger]
-t_command_restore_axis:       # The axis to restore, by default
+t_command_restore_axis: z     # The axis to restore, by default
 uses_axis: xy                 # Axis used by the tool change process
 on_axis_not_homed: abort      # When required axis are not homed. Option: 'abort' or 'home' to home the required axis
 transfer_fan_speed: True      # fan speed is transferred during toolchange
@@ -46,9 +48,9 @@ params_type = 'sb_misschanger'
 ## 'd' indicate whether the path is relevant during drop-off. "0" is no, "1" is yes
 params_sb_misschanger_path: [{'x':0,       'y':0,      'f':1.00,    'd':1},
                              {'x':0,       'y':-55,    'f':0.80,    'd':1},
-                             {'x':0,       'y':-65,    'f':0.75,    'd':0},    # Wiggle...
-                             {'x':0,       'y':-60,    'f':0.70,    'd':0},    # Wiggle...
-                             {'x':0,       'y':-70,    'f':0.70,    'd':1},
+                             {'x':0,       'y':-65,    'f':0.70,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-60,    'f':0.60,    'd':0},    # Wiggle...
+                             {'x':0,       'y':-70,    'f':0.50,    'd':1},
                              {'x':0,       'y':-62,    'f':0.45,    'd':0},    # Wiggle...
                              {'x':0,       'y':-67,    'f':0.45,    'd':0},    # Wiggle...
                              {'x':0,       'y':-65,    'f':0.45,    'd':0},    # Wiggle...


### PR DESCRIPTION
## klipper/extras/tools_calibrate.py
- clean up back-end.
- remove unnecessary output to console.

## macros/homing.cfg
- change how z-offset is interpreted. This make it simpler and more accurate.
    -  **NOTE:** the calibration routine need to be re-run.

## macros/tool_calibrate.cfg
- update calibration routine to match the new way z-offset is interpreted.

##  scripts/misschanger_settings.cfg
- add minor changes to the tool-change path, to improve reliability.